### PR TITLE
Download.sh Bugfix

### DIFF
--- a/shells/downloads.sh
+++ b/shells/downloads.sh
@@ -14,5 +14,5 @@ mv www.cs.toronto.edu/~vmnih/data ./
 rm -rf www.cs.toronto.edu
 
 mv data/mass_merged/test/map data/mass_merged/test/map_orig
-cd data/mass_merged/test; wget https://www.dropbox.com/s/yk6d4garyz3nm19/multi_test_map.tar.gz?dl=0;
+cd data/mass_merged/test; wget https://www.dropbox.com/s/yk6d4garyz3nm19/multi_test_map.tar.gz;
 tar zxvf multi_test_map.tar.gz; rm -rf multi_test_map.tar.gz


### PR DESCRIPTION
Fixes issue with Download.sh. If this command is run, it will name the file "multi_test_map.tar.gz?dl=0" which will cause the script to fail.
