### PR TITLE
Backward compatability fix

### DIFF
--- a/scripts/create_dataset.py
+++ b/scripts/create_dataset.py
@@ -119,7 +119,9 @@ def create_patches(sat_patch_size, map_patch_size, stride, map_ch,
         for patch_i in range(sat_patches.shape[0]):
             sat_patch = sat_patches[patch_i]
             map_patch = map_patches[patch_i]
-            key = b'%010d' % keys[n_patches]
+            #key = b'%010d' % keys[n_patches]
+            # The below works in <Python3.5 well the above does not.
+            key = bytes('%010d' % keys[n_patches], 'ascii') 
             sat_txn.put(key, sat_patch.tobytes())
             map_txn.put(key, map_patch.tobytes())
 


### PR DESCRIPTION
Makes the repo work if your Python framework < 3.5

This solves #3. I would recommend you accept the request as Python 3.4 is still widely used because of the many minor breaking changes that were introduced in Python 3.5. One example is that on Windows, the compiler was changed meaning that all old packages need to be recompiled. Thank you so much for the useful repo!
